### PR TITLE
Run test suite with minimum required Python

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - tiledb main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+python_min:
+- '3.9'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,5 @@ channel_sources:
   - conda-forge,tiledb
 channel_targets:
   - tiledb main
+python_min:
+  - "3.9"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,13 +20,13 @@ build:
 
 requirements:
   host:
-    - python >=3.9,<4.dev0
+    - python {{ python_min }}
     - setuptools
     - setuptools-scm
     - wheel
     - pip
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     - attrs >=22.2
     - tiledbsoma-py >=1.9.0
     - pytorch >=2.0
@@ -46,6 +46,7 @@ test:
   requires:
     - pip
     - pytest
+    - python {{ python_min }}
   source_files:
     - tests/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,12 @@ test:
     - tiledbsoma_ml
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
+  source_files:
+    - tests/
 
 about:
   summary: Machine learning tools for use with tiledbsoma (SOMA PyTorch loaders)


### PR DESCRIPTION
This PR is to facilitate long-term recipe maintenance:

* Run the test suite
* Use the [new `python_min` syntax](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python) to ensure the lower bound is truly supported
* Didn't bother bumping the build number since these changes don't affect the conda binary produced by the recipe